### PR TITLE
Force Doctrine MongoDB ODM to check indexes

### DIFF
--- a/Persister/MongoDBPersister.php
+++ b/Persister/MongoDBPersister.php
@@ -42,7 +42,8 @@ class MongoDBPersister implements PersisterInterface
      */
     public function save()
     {
-        $this->dm->flush();
+        $this->dm->getSchemaManager()->ensureIndexes();
+        $this->dm->flush(null, array('safe' => true));
     }
 
 }


### PR DESCRIPTION
MongoDBPersister now calls `ensureIndexes()` and adds the `safe` argument to `flush` in `save`. This way MongoDB creates the indexes and checks them on save.
